### PR TITLE
Add Windows test support and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:  # TODO: support windows
-        os: [ubuntu-latest, macos-latest]
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
       fail-fast: false
 
     steps:
@@ -24,6 +24,7 @@ jobs:
         with:
           submodules: recursive
 
+      # Ubuntu
       - name: Install dependencies (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: sudo apt-get update && sudo apt-get -y install rapidjson-dev
@@ -33,6 +34,19 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
             brew install boost rapidjson
+        shell: bash
+
+      # Windows
+      - name: Enable Developer Command Prompt
+        if: startsWith(matrix.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1.12.1
+
+      - name: Install dependencies (Windows)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+            git clone https://github.com/Tencent/rapidjson.git .ci.rapidjson --depth 1
+            echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/.ci.rapidjson/include/rapidjson" >> "$GITHUB_ENV"
+            echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 build
+
+# Used in windows-ci
+.ci.rapidjson
+
+# Editors
+.vscode
+.idea
+
+# clangd cache
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ find_package(RapidJSON REQUIRED MODULE)
 if (BUILD_TESTS)
     message("++ Tests enabled")
 
+    # For MSVC: Prevent overriding the parent project's compiler/linker settings
+    # See https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
     add_subdirectory(external/googletest)
 
     enable_testing()

--- a/include/pajlada/serialize/deserialize.hpp
+++ b/include/pajlada/serialize/deserialize.hpp
@@ -170,7 +170,7 @@ struct Deserialize<std::array<ValueType, Size>, RJValue> {
     static std::array<ValueType, Size>
     get(const RJValue &value, bool *error = nullptr)
     {
-        std::array<ValueType, Size> ret;
+        std::array<ValueType, Size> ret{};
 
         if (!value.IsArray()) {
             PAJLADA_REPORT_ERROR(error)


### PR DESCRIPTION
This PR adds support for testing on Windows. While running the tests, I found that [`std::array<ValueType, Size> ret;`](https://github.com/pajlada/serialize/blob/7d37cbfd5ac3bfbe046118e1cec3d32ba4696469/include/pajlada/serialize/deserialize.hpp#L173), where `ValueType` is a non-class/array type (e.g. [`int`](https://github.com/pajlada/serialize/blob/7d37cbfd5ac3bfbe046118e1cec3d32ba4696469/src/main.cpp#L40)), [will result in an indeterminate value](https://stackoverflow.com/a/18295840/16300717).

It also adds a CI job. I don't use a package manager here, since rapidjson is a header-only library.