### PR TITLE
Enable strict compiler settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,4 +60,18 @@ if (BUILD_TESTS)
         SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
         SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
     endif()
+
+    # Enable strict compiler settings
+    if (MSVC)
+        # Someone adds /W3 before we add /W4.
+        # This makes sure, only /W4 is specified.
+        string(REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+        target_compile_options(serialize-test PUBLIC
+            /W4
+            /WX # treat warnings as errors
+        )
+    else()
+        target_compile_options(serialize-test PUBLIC -Wall -Werror)
+    endif()
 endif()

--- a/include/pajlada/serialize/common.hpp
+++ b/include/pajlada/serialize/common.hpp
@@ -30,11 +30,11 @@ typename std::enable_if<std::is_integral<T1>::value, T1>::type
 Round(T2 value)
 {
 #if PAJLADA_ROUNDING_METHOD == PAJLADA_ROUNDING_METHOD_ROUND
-    return round(value);
+    return static_cast<T1>(round(value));
 #elif PAJLADA_ROUNDING_METHOD == PAJLADA_ROUNDING_METHOD_CEIL
-    return ceil(value);
+    return static_cast<T1>(ceil(value));
 #elif PAJLADA_ROUNDING_METHOD == PAJLADA_ROUNDING_METHOD_FLOOR
-    return floor(value);
+    return static_cast<T1>(floor(value));
 #else
     static_assert(
         "Invalid rounding method selected in PAJLADA_ROUNDING_METHOD");

--- a/include/pajlada/serialize/deserialize.hpp
+++ b/include/pajlada/serialize/deserialize.hpp
@@ -182,7 +182,8 @@ struct Deserialize<std::array<ValueType, Size>, RJValue> {
             return ret;
         }
 
-        for (size_t i = 0; i < Size; ++i) {
+        auto size = static_cast<rapidjson::SizeType>(Size);
+        for (rapidjson::SizeType i = 0; i < size; ++i) {
             ret[i] = Deserialize<ValueType, RJValue>::get(value[i], error);
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,8 +45,8 @@ TEST(Serialize, SerializeArrayMismatchingSize)
     bool error = false;
     auto out = Deserialize<std::array<int, 3>>::get(middle, &error);
     EXPECT_TRUE(error);
+    EXPECT_EQ(out, (std::array<int, 3>{0, 0, 0}));
 }
-
 
 TEST(Serialize, Float)
 {
@@ -63,7 +63,6 @@ TEST(Serialize, Float)
 
     EXPECT_FLOAT_EQ(in, out);
 }
-
 
 TEST(Serialize, FloatNaN)
 {
@@ -97,4 +96,5 @@ TEST(Serialize, FloatString)
     bool error = false;
     auto out = Deserialize<float>::get(middle, &error);
     EXPECT_TRUE(error);
+    EXPECT_FLOAT_EQ(out, 0.0f);
 }


### PR DESCRIPTION
This PR enables strict compiler settings.

For MSVC, `/W4 /WX` is used (level 4 warnings, treat warnings as errors) - there's `/Wall` but using this (and `/WX`) will cause errors in STL headers.

For GNU-like compilers, `-Wall -Werror` is used ("all" warnings, treat warnings as errors).