### PR TITLE
Add Support for `std::string_view`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minor: Added support for (de-)serializing from/to [std::string_view](https://en.cppreference.com/w/cpp/string/basic_string_view) (#9).
+
 ## v0.1.0
 
 - Initial release

--- a/include/pajlada/serialize/deserialize.hpp
+++ b/include/pajlada/serialize/deserialize.hpp
@@ -122,6 +122,20 @@ struct Deserialize<std::string, RJValue> {
     }
 };
 
+template <typename RJValue>
+struct Deserialize<std::string_view, RJValue> {
+    static std::string_view
+    get(const RJValue &value, bool *error = nullptr)
+    {
+        if (!value.IsString()) {
+            PAJLADA_REPORT_ERROR(error)
+            return std::string_view{};
+        }
+
+        return {value.GetString(), value.GetStringLength()};
+    }
+};
+
 template <typename ValueType, typename RJValue>
 struct Deserialize<std::map<std::string, ValueType>, RJValue> {
     static std::map<std::string, ValueType>

--- a/include/pajlada/serialize/serialize.hpp
+++ b/include/pajlada/serialize/serialize.hpp
@@ -82,6 +82,19 @@ struct Serialize<std::string, RJValue> {
     }
 };
 
+template <typename RJValue>
+struct Serialize<std::string_view, RJValue> {
+    static RJValue
+    get(const std::string_view &value, typename RJValue::AllocatorType &a)
+    {
+        rapidjson::GenericStringRef<char> ref(
+            value.data(), static_cast<rapidjson::SizeType>(value.size()));
+        RJValue ret(ref, a);
+
+        return ret;
+    }
+};
+
 template <typename Arg1, typename Arg2, typename RJValue>
 struct Serialize<std::pair<Arg1, Arg2>, RJValue> {
     static RJValue

--- a/include/pajlada/serialize/serialize.hpp
+++ b/include/pajlada/serialize/serialize.hpp
@@ -87,8 +87,11 @@ struct Serialize<std::string_view, RJValue> {
     static RJValue
     get(const std::string_view &value, typename RJValue::AllocatorType &a)
     {
+        // Workaround for older rapidjson versions:
+        // GenericStringRef and nullpointers (empty strings) wasn't supported.
+        const auto *data = value.data();
         rapidjson::GenericStringRef<char> ref(
-            value.data(), static_cast<rapidjson::SizeType>(value.size()));
+            data ? data : "", static_cast<rapidjson::SizeType>(value.size()));
         RJValue ret(ref, a);
 
         return ret;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,3 +98,48 @@ TEST(Serialize, FloatString)
     EXPECT_TRUE(error);
     EXPECT_FLOAT_EQ(out, 0.0f);
 }
+
+TEST(Deserialize, StringToStringView)
+{
+    std::string in = "forsen";
+
+    rapidjson::Document d;
+    auto middle = Serialize<std::string>::get(in, d.GetAllocator());
+
+    EXPECT_TRUE(middle.IsString());
+
+    bool error = false;
+    auto out = Deserialize<std::string_view>::get(middle, &error);
+    EXPECT_FALSE(error);
+    EXPECT_EQ(out, "forsen");
+}
+
+TEST(Serialize, StringViewToString)
+{
+    std::string_view in = "forsen";
+
+    rapidjson::Document d;
+    auto middle = Serialize<std::string_view>::get(in, d.GetAllocator());
+
+    EXPECT_TRUE(middle.IsString());
+
+    bool error = false;
+    auto out = Deserialize<std::string>::get(middle, &error);
+    EXPECT_FALSE(error);
+    EXPECT_EQ(out, "forsen");
+}
+
+TEST(Serialize, StringViewToStringView)
+{
+    std::string_view in = "forsen";
+
+    rapidjson::Document d;
+    auto middle = Serialize<std::string_view>::get(in, d.GetAllocator());
+
+    EXPECT_TRUE(middle.IsString());
+
+    bool error = false;
+    auto out = Deserialize<std::string_view>::get(middle, &error);
+    EXPECT_FALSE(error);
+    EXPECT_EQ(out, "forsen");
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+#include <rapidjson/allocators.h>
+#include <rapidjson/document.h>
 
 #include <array>
 #include <pajlada/serialize.hpp>
@@ -142,4 +144,19 @@ TEST(Serialize, StringViewToStringView)
     auto out = Deserialize<std::string_view>::get(middle, &error);
     EXPECT_FALSE(error);
     EXPECT_EQ(out, "forsen");
+}
+
+TEST(Serialize, EmptyStringView)
+{
+    std::string_view in;
+
+    rapidjson::Document d;
+    auto middle = Serialize<std::string_view>::get(in, d.GetAllocator());
+
+    EXPECT_TRUE(middle.IsString());
+
+    bool error = false;
+    auto out = Deserialize<std::string_view>::get(middle, &error);
+    EXPECT_FALSE(error);
+    EXPECT_EQ(out, "");
 }


### PR DESCRIPTION
This PR adds support for serializing and deserializing [`std::string_view`](https://en.cppreference.com/w/cpp/string/basic_string_view). This is useful when doing zero-copy (de-)serialization.