### PR TITLE
refactor: move from `boost::any` to `std::any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Breaking: Removed (de-)serialization support for `boost::any`. (#10)
+- Minor: Added support for (de-)serializing from/to [std::any](https://en.cppreference.com/w/cpp/utility/any). (#10)
 - Minor: Added support for (de-)serializing from/to [std::string_view](https://en.cppreference.com/w/cpp/string/basic_string_view) (#9).
 
 ## v0.1.0

--- a/include/pajlada/serialize/deserialize.hpp
+++ b/include/pajlada/serialize/deserialize.hpp
@@ -2,15 +2,11 @@
 
 #include <rapidjson/document.h>
 
-#include <pajlada/serialize/common.hpp>
-
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
-#include <boost/any.hpp>
-#endif
-
+#include <any>
 #include <cassert>
 #include <cmath>
 #include <map>
+#include <pajlada/serialize/common.hpp>
 #include <stdexcept>
 #include <string>
 #include <typeinfo>
@@ -225,10 +221,9 @@ struct Deserialize<std::pair<Arg1, Arg2>, RJValue> {
     }
 };
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
 template <typename RJValue>
-struct Deserialize<boost::any, RJValue> {
-    static boost::any
+struct Deserialize<std::any, RJValue> {
+    static std::any
     get(const RJValue &value, bool *error = nullptr)
     {
         if (value.IsInt()) {
@@ -240,17 +235,16 @@ struct Deserialize<boost::any, RJValue> {
         } else if (value.IsBool()) {
             return value.GetBool();
         } else if (value.IsObject()) {
-            return Deserialize<std::map<std::string, boost::any>, RJValue>::get(
+            return Deserialize<std::map<std::string, std::any>, RJValue>::get(
                 value, error);
         } else if (value.IsArray()) {
-            return Deserialize<std::vector<boost::any>, RJValue>::get(value,
-                                                                      error);
+            return Deserialize<std::vector<std::any>, RJValue>::get(value,
+                                                                    error);
         }
 
         PAJLADA_REPORT_ERROR(error)
-        return boost::any();
+        return {};
     }
 };
-#endif
 
 }  // namespace pajlada

--- a/include/pajlada/serialize/serialize.hpp
+++ b/include/pajlada/serialize/serialize.hpp
@@ -2,15 +2,11 @@
 
 #include <rapidjson/document.h>
 
-#include <pajlada/serialize/common.hpp>
-
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
-#include <boost/any.hpp>
-#endif
-
+#include <any>
 #include <cassert>
 #include <cmath>
 #include <map>
+#include <pajlada/serialize/common.hpp>
 #include <stdexcept>
 #include <typeinfo>
 #include <vector>
@@ -160,15 +156,14 @@ struct Serialize<std::array<ValueType, Size>, RJValue> {
     }
 };
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
 template <typename RJValue>
-struct Serialize<boost::any, RJValue> {
+struct Serialize<std::any, RJValue> {
     static RJValue
-    get(const boost::any &value, typename RJValue::AllocatorType &a)
+    get(const std::any &value, typename RJValue::AllocatorType &a)
     {
-        using boost::any_cast;
+        using std::any_cast;
 
-        if (value.empty()) {
+        if (!value.has_value()) {
             return RJValue(rapidjson::kNullType);
         }
 
@@ -186,23 +181,22 @@ struct Serialize<boost::any, RJValue> {
         } else if (value.type() == typeid(const char *)) {
             return Serialize<std::string, RJValue>::get(
                 any_cast<const char *>(value), a);
-        } else if (value.type() == typeid(std::map<std::string, boost::any>)) {
-            return Serialize<std::map<std::string, boost::any>, RJValue>::get(
-                any_cast<std::map<std::string, boost::any>>(value), a);
-        } else if (value.type() == typeid(std::vector<boost::any>)) {
-            return Serialize<std::vector<boost::any>, RJValue>::get(
-                any_cast<std::vector<boost::any>>(value), a);
+        } else if (value.type() == typeid(std::map<std::string, std::any>)) {
+            return Serialize<std::map<std::string, std::any>, RJValue>::get(
+                any_cast<std::map<std::string, std::any>>(value), a);
+        } else if (value.type() == typeid(std::vector<std::any>)) {
+            return Serialize<std::vector<std::any>, RJValue>::get(
+                any_cast<std::vector<std::any>>(value), a);
         } else if (value.type() == typeid(std::vector<std::string>)) {
             return Serialize<std::vector<std::string>, RJValue>::get(
                 any_cast<std::vector<std::string>>(value), a);
         } else {
-            // PS_DEBUG("[boost::any] Serialize: Unknown type of value");
+            // PS_DEBUG("[std::any] Serialize: Unknown type of value");
         }
 
         return RJValue(rapidjson::kNullType);
     }
 };
-#endif
 
 namespace detail {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,7 +179,7 @@ TEST(Serialize, SimpleAnyMap)
     EXPECT_TRUE(out.size() == 3);
     EXPECT_TRUE(any_cast<int>(out["a"]) == 1);
     EXPECT_TRUE(any_cast<std::string>(out["b"]) == "asd");
-    EXPECT_TRUE(any_cast<double>(out["c"]) == 3.14);
+    EXPECT_DOUBLE_EQ(any_cast<double>(out["c"]), 3.14);
 }
 
 TEST(Serialize, ComplexAnyMap)
@@ -237,7 +237,7 @@ TEST(Serialize, ComplexAnyMap)
     EXPECT_TRUE(innerMap.size() == 3);
     EXPECT_TRUE(any_cast<int>(innerMap["a"]) == 420);
     EXPECT_TRUE(any_cast<int>(innerMap["b"]) == 320);
-    EXPECT_TRUE(any_cast<double>(innerMap["c"]) == 13.37);
+    EXPECT_DOUBLE_EQ(any_cast<double>(innerMap["c"]), 13.37);
 
     auto innerArray = any_cast<std::vector<std::any>>(out["innerArray"]);
     EXPECT_TRUE(innerArray.size() == 9);
@@ -248,7 +248,7 @@ TEST(Serialize, ComplexAnyMap)
     EXPECT_TRUE(any_cast<std::string>(innerArray[4]) == "testman");
     EXPECT_TRUE(any_cast<bool>(innerArray[5]) == true);
     EXPECT_TRUE(any_cast<bool>(innerArray[6]) == false);
-    EXPECT_TRUE(any_cast<double>(innerArray[7]) == 4.20);
+    EXPECT_DOUBLE_EQ(any_cast<double>(innerArray[7]), 4.20);
 
     auto innerArrayMap =
         any_cast<std::map<std::string, std::any>>(innerArray[8]);


### PR DESCRIPTION
As I move `pajlada/settings` to `std::any` I first need to move this to `std::any`.