### PR TITLE
cmake: rename RapidJSON declaration to `rjlib`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include(FetchContent)
 option(PAJLADA_SERIALIZE_BUILD_TESTS "Build tests" OFF)
 
 FetchContent_Declare(
-    rapidjson
+    rjlib
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/external/rapidjson
     EXCLUDE_FROM_ALL
     FIND_PACKAGE_ARGS NAMES RapidJSON
@@ -25,7 +25,7 @@ FetchContent_Declare(
 set(RAPIDJSON_BUILD_EXAMPLES Off CACHE INTERNAL "")
 set(RAPIDJSON_BUILD_TESTS Off CACHE INTERNAL "")
 
-FetchContent_MakeAvailable(rapidjson)
+FetchContent_MakeAvailable(rjlib)
 
 add_library(PajladaSerialize INTERFACE)
 add_library(Pajlada::Serialize ALIAS PajladaSerialize)


### PR DESCRIPTION
This helps alleviate an issue with some weird imports happening that is
causing reconfigures on Windows to fail.
