### PR TITLE
chore: add install targets for PajladaSerialize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.1.1)
-set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY On) # For rapidjson
+cmake_minimum_required(VERSION 3.25...4.1.1)
 
 list(APPEND CMAKE_MESSAGE_CONTEXT PajladaSerialize)
 project(
@@ -13,40 +12,71 @@ project(
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-include(FetchContent)
+include(GNUInstallDirs)
 
 option(PAJLADA_SERIALIZE_BUILD_TESTS "Build tests" OFF)
-
-FetchContent_Declare(
-    RapidJSON
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/external/rapidjson
-    EXCLUDE_FROM_ALL
-    FIND_PACKAGE_ARGS
-)
-set(RAPIDJSON_BUILD_EXAMPLES Off CACHE INTERNAL "")
-set(RAPIDJSON_BUILD_TESTS Off CACHE INTERNAL "")
-
-FetchContent_MakeAvailable(RapidJSON)
+option(PAJLADA_SERIALIZE_INSTALL "Install PajladaSerialize" ${PROJECT_IS_TOP_LEVEL})
 
 add_library(PajladaSerialize INTERFACE)
 add_library(Pajlada::Serialize ALIAS PajladaSerialize)
 
+set_target_properties(PajladaSerialize PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    EXPORT_NAME Serialize
+)
+
+add_subdirectory(include)
+
 # Enable std::string overloads
 target_compile_definitions(PajladaSerialize INTERFACE RAPIDJSON_HAS_STDSTRING=1)
-
-target_include_directories(PajladaSerialize INTERFACE include)
-if(TARGET rapidjson)
-    message(DEBUG "Linking to rapidjson target")
-    target_link_libraries(PajladaSerialize INTERFACE rapidjson)
-elseif(DEFINED RapidJSON_SOURCE_DIR)
-    message(DEBUG "RapidJSON_SOURCE_DIR defined, assuming this is a submodule/source build. (${RapidJSON_SOURCE_DIR})")
-    target_include_directories(PajladaSerialize SYSTEM INTERFACE ${RapidJSON_SOURCE_DIR}/include)
-else()
-    message(DEBUG "No rapidjson target found, this is most likely a system install. Adding include directories (${RAPIDJSON_INCLUDE_DIRS}) instead")
-    target_include_directories(PajladaSerialize SYSTEM INTERFACE ${RAPIDJSON_INCLUDE_DIRS})
-endif()
 
 if(PAJLADA_SERIALIZE_BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
+endif()
+
+if(PAJLADA_SERIALIZE_INSTALL)
+    include(CMakePackageConfigHelpers)
+
+    # Install header files
+    install(TARGETS PajladaSerialize
+        EXPORT SerializeTargets
+        FILE_SET headers
+    )
+
+    # Export(?) & install the Targets.cmake file
+    install(EXPORT SerializeTargets
+        FILE PajladaSerializeTargets.cmake
+        NAMESPACE "Pajlada::"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    )
+
+    # Write the ConfigVersion.cmake and Config.cmake files and install them into lib/cmake/ProjectName/
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/PajladaSerializeConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY AnyNewerVersion
+    )
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/PajladaSerializeConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/PajladaSerializeConfig.cmake
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PajladaSerialize"
+        NO_CHECK_REQUIRED_COMPONENTS_MACRO
+    )
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/PajladaSerializeConfigVersion.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/PajladaSerializeConfig.cmake
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    )
+endif()
+
+if(NOT PROJECT_IS_TOP_LEVEL)
+    return(PROPAGATE
+        PajladaSerialize_VERSION
+        PajladaSerialize_VERSION_MAJOR
+        PajladaSerialize_VERSION_MINOR
+        PajladaSerialize_VERSION_PATCH
+        PajladaSerialize_VERSION_TWEAK
+    )
 endif()

--- a/cmake/PajladaSerializeConfig.cmake.in
+++ b/cmake/PajladaSerializeConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/PajladaSerializeTargets.cmake)
+
+add_library(PajladaSerialize ALIAS Pajlada::Serialize)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,12 @@
+target_sources(PajladaSerialize INTERFACE
+    FILE_SET headers TYPE HEADERS FILES
+    pajlada/serialize.hpp
+    pajlada/serialize/common.hpp
+    pajlada/serialize/deserialize.hpp
+    pajlada/serialize/serialize.hpp
+)
+
+target_include_directories(PajladaSerialize INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,15 +1,27 @@
 cmake_minimum_required(VERSION 3.15...4.0)
+set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY On) # For rapidjson
 
 project(serialize-test)
 
 # For MSVC: Prevent overriding the parent project's compiler/linker settings
 # See https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Ensure we don't install googletest
+set(INSTALL_GTEST OFF CACHE INTERNAL "")
 
 include(GoogleTest)
 include(FetchContent)
 
 option(PAJLADA_SERIALIZE_BUILD_COVERAGE "Build coverage" OFF)
+
+FetchContent_Declare(
+    RapidJSON
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../external/rapidjson
+    EXCLUDE_FROM_ALL
+    FIND_PACKAGE_ARGS
+)
+set(RAPIDJSON_BUILD_EXAMPLES Off CACHE INTERNAL "")
+set(RAPIDJSON_BUILD_TESTS Off CACHE INTERNAL "")
 
 FetchContent_Declare(
     googletest
@@ -18,7 +30,7 @@ FetchContent_Declare(
     FIND_PACKAGE_ARGS NAMES GTest
 )
 
-FetchContent_MakeAvailable(googletest)
+FetchContent_MakeAvailable(RapidJSON googletest)
 
 enable_testing()
 
@@ -30,6 +42,17 @@ add_executable(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} PRIVATE Pajlada::Serialize)
 target_link_libraries(${PROJECT_NAME} PRIVATE gtest)
 target_link_libraries(${PROJECT_NAME} PRIVATE gtest_main)
+
+if(TARGET rapidjson)
+    message(STATUS "Linking to rapidjson target")
+    target_link_libraries(${PROJECT_NAME} PRIVATE rapidjson)
+elseif(DEFINED RapidJSON_SOURCE_DIR)
+    message(STATUS "RapidJSON_SOURCE_DIR defined, assuming this is a submodule/source build. (${RapidJSON_SOURCE_DIR})")
+    target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${RapidJSON_SOURCE_DIR}/include)
+else()
+    message(STATUS "No rapidjson target found, this is most likely a system install. Adding include directories (${RAPIDJSON_INCLUDE_DIRS}) instead")
+    target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
+endif()
 
 gtest_discover_tests(${PROJECT_NAME})
 


### PR DESCRIPTION
This installs the header files to CMAKE_INSTALL_INCLUDEDIR, and CMake
files to CMAKE_INSTALL_LIBDIR, e.g.:
```
-- Installing: /usr/include/pajlada/serialize.hpp
-- Installing: /usr/include/pajlada/serialize/common.hpp
-- Installing: /usr/include/pajlada/serialize/deserialize.hpp
-- Installing: /usr/include/pajlada/serialize/serialize.hpp
-- Installing: /usr/lib/cmake/PajladaSerialize/PajladaSerializeTargets.cmake
-- Installing: /usr/lib/cmake/PajladaSerialize/PajladaSerializeConfigVersion.cmake
-- Installing: /usr/lib/cmake/PajladaSerialize/PajladaSerializeConfig.cmake
```

After installation, a library can import the library with find_package(PajladaSerialize)
