### PR TITLE
dev: provide example project that can easily be built in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 /build*
 
+/examples/*/build*
 /external/rapidjson
 
 /logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /build
 /build-*
 
+/examples/*/build
+/examples/*/build-*
+
 # Used in windows-ci
 .ci.rapidjson
 

--- a/examples/IncludePajladaSerialize.cmake
+++ b/examples/IncludePajladaSerialize.cmake
@@ -1,0 +1,29 @@
+option(EXAMPLE_IMPORT_METHOD "Method to use when trying to import PajladaSerialize. Valid options are: SOURCE_DIR (default), FIND_PACKAGE, and GIT.")
+string(TOUPPER "${EXAMPLE_IMPORT_METHOD}" _example_import_method)
+
+if(_example_import_method STREQUAL "SOURCE_DIR" OR NOT EXAMPLE_IMPORT_METHOD)
+    message(STATUS "Using SOURCE_DIR import method")
+    FetchContent_Declare(
+        PajladaSerialize
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../
+        EXCLUDE_FROM_ALL
+    )
+elseif(_example_import_method STREQUAL "GIT")
+    message(STATUS "Using GIT import method")
+    FetchContent_Declare(
+        PajladaSerialize
+        GIT_REPOSITORY https://github.com/pajlada/serialize
+        GIT_TAG master
+        EXCLUDE_FROM_ALL
+    )
+elseif(_example_import_method STREQUAL "FIND_PACKAGE")
+    message(STATUS "Using FIND_PACKAGE import method")
+    FetchContent_Declare(
+        PajladaSerialize
+        EXCLUDE_FROM_ALL
+        FIND_PACKAGE_ARGS CONFIG REQUIRED
+    )
+else()
+    message(FATAL_ERROR "Unknown example import method '${_example_import_method}'")
+endif()
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,1 @@
+This directory contains some standalone example projects using the PajladaSerialize library.

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.15...4.2.1)
+set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY On) # For rapidjson
+
+project(PajladaSerializeSimple)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(${PROJECT_NAME} main.cpp)
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    OUTPUT_NAME "out"
+)
+
+include(FetchContent)
+
+FetchContent_Declare(
+    RapidJSON
+    EXCLUDE_FROM_ALL
+    FIND_PACKAGE_ARGS
+)
+set(RAPIDJSON_BUILD_EXAMPLES Off CACHE INTERNAL "")
+set(RAPIDJSON_BUILD_TESTS Off CACHE INTERNAL "")
+
+include(${CMAKE_CURRENT_LIST_DIR}/../IncludePajladaSerialize.cmake)
+
+FetchContent_MakeAvailable(RapidJSON PajladaSerialize)
+
+if(TARGET rapidjson)
+    message(STATUS "Linking to rapidjson target")
+    target_link_libraries(${PROJECT_NAME} PRIVATE rapidjson)
+elseif(DEFINED RapidJSON_SOURCE_DIR)
+    message(STATUS "RapidJSON_SOURCE_DIR defined, assuming this is a submodule/source build. (${RapidJSON_SOURCE_DIR})")
+    target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${RapidJSON_SOURCE_DIR}/include)
+else()
+    message(STATUS "No rapidjson target found, this is most likely a system install. Adding include directories (${RAPIDJSON_INCLUDE_DIRS}) instead")
+    target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
+endif()
+
+if (TARGET PajladaSerialize)
+    message(STATUS "FOUND PAJLADA SERIALIZE TARGET")
+else()
+    message(STATUS "No pajlada serialize target found")
+endif ()
+
+target_link_libraries(${PROJECT_NAME} PRIVATE PajladaSerialize)

--- a/examples/simple/main.cpp
+++ b/examples/simple/main.cpp
@@ -1,0 +1,18 @@
+#include <rapidjson/allocators.h>
+#include <rapidjson/document.h>
+
+#include <iostream>
+#include <pajlada/serialize.hpp>
+
+int
+main(int argc, char **argv)
+{
+    int value = 5;
+    rapidjson::Document d;
+    auto middle = pajlada::Serialize<int>::get(value, d.GetAllocator());
+
+    bool error = false;
+    auto out = pajlada::Deserialize<int>::get(middle, &error);
+    std::cout << "test: " << value << " == " << out << '\n';
+    return 0;
+}

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -5,7 +5,11 @@ _build_types=("system" "conan" "submodule")
 
 for _fedora_version in "${_fedora_versions[@]}"; do
     for _build_type in "${_build_types[@]}"; do
-        docker build -f .docker/Dockerfile.fedora --tag "pajlada-serialize:fedora-${_fedora_version}-${_build_type}" --build-arg BUILD_TYPE="${_build_type}" . &
+        docker build \
+            -f .docker/Dockerfile.fedora \
+            --tag "pajlada-serialize:fedora-${_fedora_version}-${_build_type}" \
+            --build-arg BUILD_TYPE="${_build_type}" \
+            . &
     done
 done
 

--- a/scripts/docker-example.sh
+++ b/scripts/docker-example.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+_fedora_versions=("41" "42" "43" "44")
+_build_types=("system")
+_example_import_methods=("SOURCE_DIR" "GIT" "FIND_PACKAGE")
+
+for _fedora_version in "${_fedora_versions[@]}"; do
+    for _build_type in "${_build_types[@]}"; do
+        for _example_import_method in "${_example_import_methods[@]}"; do
+            (
+                _filename="logs/docker-example-${_fedora_version}-${_build_type}-${_example_import_method}.txt"
+                echo "START docker example fedora ${_fedora_version} ${_build_type} $(date)" | tee -a "$_filename"
+                if docker run --rm "pajlada-serialize:fedora-${_fedora_version}-${_build_type}" ./scripts/run-example.sh "$_example_import_method" 2>&1 | tee -a "$_filename"; then
+                    echo "DONE docker example fedora ${_fedora_version} ${_build_type} $(date)" | tee -a "$_filename"
+                else
+                    echo "ERROR docker example fedora ${_fedora_version} ${_build_type} $(date)" | tee -a "$_filename"
+                fi
+                ) &
+        done
+    done
+done
+
+wait
+
+echo "done xd"

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
+set -o pipefail
+
 _fedora_versions=("41" "42" "43" "44")
 _build_types=("system" "conan" "submodule")
 
 for _fedora_version in "${_fedora_versions[@]}"; do
     for _build_type in "${_build_types[@]}"; do
         (
-            _filename="logs/docker-${_fedora_version}-${_build_type}.txt"
+            _filename="logs/docker-test-${_fedora_version}-${_build_type}.txt"
             echo "START docker test fedora ${_fedora_version} ${_build_type} $(date)" | tee -a "$_filename"
-            docker run --rm "pajlada-serialize:fedora-${_fedora_version}-${_build_type}" 2>&1 | tee -a "$_filename"
-            echo "DONE docker test fedora ${_fedora_version} ${_build_type} $(date)" | tee -a "$_filename"
+            if docker run --rm "pajlada-serialize:fedora-${_fedora_version}-${_build_type}" 2>&1 | tee -a "$_filename"; then
+                echo "DONE docker test fedora ${_fedora_version} ${_build_type} $(date)" | tee -a "$_filename"
+            else
+                echo "ERROR docker test fedora ${_fedora_version} ${_build_type} $(date)" | tee -a "$_filename"
+            fi
             ) &
     done
 done

--- a/scripts/run-example.sh
+++ b/scripts/run-example.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+EXAMPLE_IMPORT_METHOD="$1"
+
+echo "Example import type: ${EXAMPLE_IMPORT_METHOD}"
+
+cat /etc/os-release
+
+mkdir build
+
+cmake -GNinja \
+    --log-level=DEBUG \
+    --log-context \
+    --debug-output \
+    --debug-find \
+    --preset release \
+    -B build \
+    -S .
+
+cmake --build build
+cmake --install build
+
+_examples=("simple")
+for _example in "${_examples[@]}"; do
+    mkdir "examples/${_example}/build"
+    cmake -GNinja \
+        --log-level=DEBUG \
+        --log-context \
+        --debug-output \
+        --debug-find \
+        -DEXAMPLE_IMPORT_METHOD="${EXAMPLE_IMPORT_METHOD}" \
+        -B "examples/${_example}/build" \
+        -S "examples/${_example}"
+    cmake --build "examples/${_example}/build"
+    "./examples/${_example}/build/out"
+done

--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -13,9 +13,9 @@ fi
 mkdir build && cd build
 
 if [ "$BUILD_TYPE" = "conan" ]; then
-    cmake -GNinja --log-level=DEBUG --log-context --debug-output --preset debug-conan ..
+    cmake -GNinja --log-level=DEBUG --log-context --debug-output --debug-find --preset debug-conan ..
 else
-    cmake -GNinja --log-level=DEBUG --log-context --debug-output --preset debug ..
+    cmake -GNinja --log-level=DEBUG --log-context --debug-output --debug-find --preset debug ..
 fi
 
 cmake --build .


### PR DESCRIPTION
using docker-example.sh will build & run the example and output the logs
to the logs directory, meaning we can somewhat trivially ensure that the
library can be imported via:
1. a git submodule
2. a git URL + commit hash/tag
3. system-installation (i.e. `cmake --install` of the library)
