### PR TITLE
dev: add some internal logging tools

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,7 +6,8 @@
       "displayName": "Debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "PAJLADA_SERIALIZE_BUILD_TESTS": true
+        "PAJLADA_SERIALIZE_BUILD_TESTS": true,
+        "PAJLADA_SERIALIZE_VERBOSE_TESTS": true
       }
     },
     {

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(PajladaSerialize INTERFACE
     pajlada/serialize/common.hpp
     pajlada/serialize/deserialize.hpp
     pajlada/serialize/serialize.hpp
+    pajlada/serialize/internal.hpp
 )
 
 target_include_directories(PajladaSerialize INTERFACE

--- a/include/pajlada/serialize/internal.hpp
+++ b/include/pajlada/serialize/internal.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#ifdef PAJLADA_SERIALIZE_LOG_VERBOSE
+
+#include <rapidjson/document.h>      // IWYU pragma: keep
+#include <rapidjson/prettywriter.h>  // IWYU pragma: keep
+#include <rapidjson/writer.h>        // IWYU pragma: keep
+
+#include <iostream>  // IWYU pragma: keep
+
+#endif
+
+namespace pajlada::internal {
+
+#ifdef PAJLADA_SERIALIZE_LOG_VERBOSE
+
+inline std::string
+pp(const rapidjson::Value &v)
+{
+    rapidjson::StringBuffer buffer;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
+    v.Accept(writer);
+    return {buffer.GetString()};
+}
+
+#define PSE_DEBUG(x) std::cout << x << '\n';
+#else
+#define PSE_DEBUG(x)
+#endif
+
+}  // namespace pajlada::internal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,8 @@ include(GoogleTest)
 include(FetchContent)
 
 option(PAJLADA_SERIALIZE_BUILD_COVERAGE "Build coverage" OFF)
+option(PAJLADA_SERIALIZE_VERBOSE_TESTS "Verbose tests" OFF)
+mark_as_advanced(PAJLADA_SERIALIZE_VERBOSE_TESTS)
 
 FetchContent_Declare(
     RapidJSON
@@ -42,6 +44,10 @@ add_executable(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} PRIVATE Pajlada::Serialize)
 target_link_libraries(${PROJECT_NAME} PRIVATE gtest)
 target_link_libraries(${PROJECT_NAME} PRIVATE gtest_main)
+
+if (PAJLADA_SERIALIZE_VERBOSE_TESTS)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC PAJLADA_SERIALIZE_LOG_VERBOSE)
+endif ()
 
 if(TARGET rapidjson)
     message(STATUS "Linking to rapidjson target")


### PR DESCRIPTION
makes it a bit easier to check what happens in tests

`cmake -DPAJLADA_SERIALIZE_VERBOSE_TESTS=On`
